### PR TITLE
chore: use named catalogs

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,7 +23,6 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "eslint": "catalog:",
-    "turbo": "catalog:",
     "typescript": "5.9.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,6 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "eslint": "catalog:",
-    "turbo": "catalog:",
     "typescript": "5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "prettier": "catalog:",
-    "turbo": "catalog:",
+    "turbo": "catalog:turbo",
     "typescript": "5.9.2"
   },
   "packageManager": "pnpm@10.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,12 +54,13 @@ catalogs:
     react-dom:
       specifier: ^19.1.0
       version: 19.1.0
-    turbo:
-      specifier: ^2.5.8
-      version: 2.5.8
     typescript-eslint:
       specifier: ^8.40.0
       version: 8.40.0
+  turbo:
+    turbo:
+      specifier: 2.5.8
+      version: 2.5.8
 
 importers:
 
@@ -69,7 +70,7 @@ importers:
         specifier: 'catalog:'
         version: 3.6.2
       turbo:
-        specifier: 'catalog:'
+        specifier: catalog:turbo
         version: 2.5.8
       typescript:
         specifier: 5.9.2
@@ -108,9 +109,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.34.0
-      turbo:
-        specifier: 'catalog:'
-        version: 2.5.8
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -148,9 +146,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.34.0
-      turbo:
-        specifier: 'catalog:'
-        version: 2.5.8
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,5 +18,8 @@ catalog:
   prettier: ^3.6.2
   react: ^19.1.0
   react-dom: ^19.1.0
-  turbo: ^2.5.8
   typescript-eslint: ^8.40.0
+
+catalogs:
+  turbo:
+    turbo: 2.5.8


### PR DESCRIPTION
## Summary

- use named catalogs `catalog:turbo` instead of the single default catalog
- remove catalog as devDep from non-root workspaces